### PR TITLE
new package: ocaml-stdcompat

### DIFF
--- a/Formula/camlp5.rb
+++ b/Formula/camlp5.rb
@@ -4,6 +4,7 @@ class Camlp5 < Formula
   url "https://github.com/camlp5/camlp5/archive/rel8.00.tar.gz"
   sha256 "906d5325798cd0985a634e9b6b5c76c6810f3f3b8e98b80a7c30b899082c2332"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/camlp5/camlp5.git"
 
   livecheck do

--- a/Formula/coccinelle.rb
+++ b/Formula/coccinelle.rb
@@ -23,6 +23,7 @@ class Coccinelle < Formula
   depends_on "automake" => :build
   depends_on "hevea" => :build
   depends_on "opam" => :build
+  depends_on "ocaml-stdcompat" => :build
   depends_on "ocaml"
 
   def install

--- a/Formula/lablgtk.rb
+++ b/Formula/lablgtk.rb
@@ -4,7 +4,7 @@ class Lablgtk < Formula
   url "https://github.com/garrigue/lablgtk/archive/2.18.11.tar.gz"
   sha256 "ff3c551df4e220b0c0fb9a3da6429413bff14f8fc93f4dd6807a35463982c863"
   license "LGPL-2.1"
-  revision 2
+  revision 3
 
   livecheck do
     url :stable

--- a/Formula/ocaml-num.rb
+++ b/Formula/ocaml-num.rb
@@ -4,7 +4,7 @@ class OcamlNum < Formula
   url "https://github.com/ocaml/num/archive/v1.4.tar.gz"
   sha256 "015088b68e717b04c07997920e33c53219711dfaf36d1196d02313f48ea00f24"
   license "LGPL-2.1"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "fc2e933047de0f32e0802f2233202c076098e1c18669a2bfb266ae1ddf357e74"

--- a/Formula/ocaml-stdcompat.rb
+++ b/Formula/ocaml-stdcompat.rb
@@ -1,0 +1,22 @@
+class OcamlStdcompat < Formula
+  desc "compatibility module for OCaml standard library"
+  homepage "https://github.com/thierry-martinez/stdcompat"
+  url "https://github.com/thierry-martinez/stdcompat/releases/download/v15/stdcompat-15.tar.gz"
+  sha256 "5e746f68ffe451e7dabe9d961efeef36516b451f35a96e174b8f929a44599cf5"
+  license "BSD-2-Clause"
+  revision 1
+
+  depends_on "automake" => :build
+  depends_on "ocaml-findlib" => :build
+  depends_on "ocaml"
+
+  def install
+    system "./configure"
+    system "make -j1"
+    system "make", "install"
+  end
+
+  test do
+    system "make", "test"
+  end
+end

--- a/Formula/ocaml-zarith.rb
+++ b/Formula/ocaml-zarith.rb
@@ -4,7 +4,7 @@ class OcamlZarith < Formula
   url "https://github.com/ocaml/Zarith/archive/release-1.11.tar.gz"
   sha256 "f996af120a10fd06a8272ae99b7affd57cef49c57a3a596e2f589147dd183684"
   license "LGPL-2.0-only"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "54144ec55af567f0b567f945dac178de3d20ce3dc211b73bbaee75776cd24603"

--- a/Formula/ocaml.rb
+++ b/Formula/ocaml.rb
@@ -13,8 +13,8 @@
 class Ocaml < Formula
   desc "General purpose programming language in the ML family"
   homepage "https://ocaml.org/"
-  url "https://caml.inria.fr/pub/distrib/ocaml-4.10/ocaml-4.10.2.tar.xz"
-  sha256 "96871461078282d5db022077d89bde25c85fb5e376612b44f8c37d4e84f000e3"
+  url "https://caml.inria.fr/pub/distrib/ocaml-4.12/ocaml-4.12.0.tar.xz"
+  sha256 "39ee9db8dc1e3eb65473dd81a71fabab7cc253dbd7b85e9f9b5b28271319bec3"
   license "LGPL-2.1-only" => { with: "OCaml-LGPL-linking-exception" }
   head "https://github.com/ocaml/ocaml.git", branch: "trunk"
 

--- a/Formula/unison.rb
+++ b/Formula/unison.rb
@@ -4,6 +4,7 @@ class Unison < Formula
   url "https://github.com/bcpierce00/unison/archive/v2.51.3.tar.gz"
   sha256 "0c287d17f52729440b2bdc28edf4d19b2d5ea5869983d78e780d501c5866914b"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/bcpierce00/unison.git", branch: "master"
 
   # The "latest" release on GitHub sometimes points to unstable versions (e.g.,
@@ -22,6 +23,15 @@ class Unison < Formula
   end
 
   depends_on "ocaml" => :build
+
+  # Patch to fix build with ocaml 4.12. Remove when one of
+  # https://github.com/bcpierce00/unison/pull/480 or
+  # https://github.com/bcpierce00/unison/pull/481
+  # is merged and lands in a release.
+  patch do
+    url "https://github.com/bcpierce00/unison/compare/6d7a131bcf5e03cc7468d08c61379b350472c7e2..6dd7e7f96d4a7d7a356f3c2cff2baa6c14bf13af.patch?full_index=1"
+    sha256 "7a6936c0ffda056521e433e5b9a5d1a8a45669869336a10203c339dc99dfb7f1"
+  end
 
   def install
     ENV.deparallelize


### PR DESCRIPTION
Make coccinelle compile on OCaml 4.12.0

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
